### PR TITLE
support mulitcolumn floating

### DIFF
--- a/ox-latex-subfigure.el
+++ b/ox-latex-subfigure.el
@@ -68,15 +68,17 @@ LIMIT is limit."
         (option "")
         (centering "")
         (caption "")
+        (multicolumn "")
         fig cap)
     (beginning-of-line)
-    (while (not (looking-at "^\\\\end{table}"))
+    (while (not (looking-at "^\\\\end{table\\*?}"))
       (let ((row (thing-at-point 'line t)))
         (kill-whole-line)
         (cond
          ;; \begin{table}[option], \end{table}
-         ((string-match "^\\\\begin{table}\\(\\[.*\\]\\)?" row)
-          (setq option (or (match-string 1 row) "")))
+         ((string-match "^\\\\begin{table\\(\\*\\)?}\\(\\[.*\\]\\)?" row)
+          (setq multicolumn (or (match-string 1 row) ""))
+          (setq option (or (match-string 2 row) "")))
          ;; \centering
          ((string-match "^\\\\centering" row)
           (setq centering "\\centering\n"))
@@ -139,7 +141,7 @@ LIMIT is limit."
             (setq striped-row (replace-regexp-in-string "\\\\\\\\\n$" "" row))
             (setq cap (append cap (split-string striped-row " & "))))))))
     (kill-whole-line)
-    (insert (format "\\begin{figure}%s\n%s%s" option
+    (insert (format "\\begin{figure%s}%s\n%s%s" multicolumn option
                     (if (member 'subfigure org-latex-caption-above) caption "")
                     centering))
     (dotimes (i (length fig))
@@ -156,11 +158,12 @@ LIMIT is limit."
           (when (and (> limit 0)
                      (< i (1- (length fig)))
                      (= (mod (1+ i) limit) 0))
-            (insert (format "\\end{figure}\n
-\\begin{figure}%s
-%s\\ContinuedFloat\n" option centering))))))
-    (insert (format "%s\\end{figure}\n"
-                    (if (member 'subfigure org-latex-caption-above) "" caption)))))
+            (insert (format "\\end{figure%s}\n
+\\begin{figure%s}%s
+%s\\ContinuedFloat\n" multicolumn multicolumn option centering))))))
+    (insert (format "%s\\end{figure%s}\n"
+                    (if (member 'subfigure org-latex-caption-above) "" caption)
+		    multicolumn))))
 
 (add-hook 'org-export-filter-table-functions
           'ox-latex-subfigure-org-export-table-to-subfigure)


### PR DESCRIPTION
With "#+ATTR_LATEX: :environment subfigure :float multicolumn",
ox-latex-subfigure-latex-table-to-subfigure() cannot convert the table
to figures. This is because the multicolumn floating use
"\begin{table*}" and "\end{table*}" instead of "\begin{table}" and
"\end{table}".

This commit introduces "multicolumn" variable to capture the "*" and
output it properly.