### PR TITLE
Deal with caption without newlines

### DIFF
--- a/ox-latex-subfigure.el
+++ b/ox-latex-subfigure.el
@@ -139,7 +139,7 @@ LIMIT is limit."
                                     (?\} -1)
                                     (otherwise 0)))
                      (brace-balance (str)
-                                    (cl-reduce '+ (mapcar 'brace-score str))))
+                                    (cl-reduce '+ (mapcar #'brace-score str))))
             (let ((open-brace (brace-balance row)))
               (while (/= open-brace 0)
                 (let ((line (thing-at-point 'line t)))

--- a/ox-latex-subfigure.el
+++ b/ox-latex-subfigure.el
@@ -34,6 +34,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'ox-latex)
 (require 'org-loaddefs)
 
@@ -143,7 +144,7 @@ LIMIT is limit."
               (while (/= open-brace 0)
                 (let ((line (thing-at-point 'line t)))
                   (kill-whole-line)
-                  (incf open-brace (brace-balance line))
+                  (cl-incf open-brace (brace-balance line))
                   (setq caption (concat caption line)))))))
          ;; table row
          ((string-match ".*\\\\\\\\$" row)

--- a/ox-latex-subfigure.el
+++ b/ox-latex-subfigure.el
@@ -134,12 +134,12 @@ LIMIT is limit."
          ((string-match "^\\\\caption[\\\\[{]" row)
           (setq caption row)
           (cl-flet* ((brace-score (ch)
-                                  (case ch
+                                  (cl-case ch
                                     (?\{ 1)
                                     (?\} -1)
                                     (otherwise 0)))
                      (brace-balance (str)
-                                    (reduce '+ (mapcar 'brace-score str))))
+                                    (cl-reduce '+ (mapcar 'brace-score str))))
             (let ((open-brace (brace-balance row)))
               (while (/= open-brace 0)
                 (let ((line (thing-at-point 'line t)))


### PR DESCRIPTION
The current implementation assumes captions of the form
```latex
\caption{\label{label} %newline here
caption}
```
. Some setup (perhaps a problem of org-mode versions) generates captions of the form
```latex
\caption{\label{label}caption}
```
, resulting in `\centering` at the next line to be consumed as a part of the caption.

This PR fixes this issue. Things would break down when a caption contains something like `$\{$`, but
```latex
\newcommand{\myleftbrace}{\{}
```
 would be a workaround.